### PR TITLE
hw/drivers/uwb_dw100: update RF_TXTRL value for channel 5

### DIFF
--- a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h
+++ b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h
@@ -1001,7 +1001,7 @@ extern "C" {
 #define RF_TXCTRL_CH2           0x00045CA0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
 #define RF_TXCTRL_CH3           0x00086CC0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
 #define RF_TXCTRL_CH4           0x00045C80UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
-#define RF_TXCTRL_CH5           0x001E3FE0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+#define RF_TXCTRL_CH5           0x001E3FE3UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
 #define RF_TXCTRL_CH7           0x001E7DE0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
 
 /* offset from TX_CAL_ID in bytes */


### PR DESCRIPTION
This PR aligns `RF_TXCTRL` values for channel 5 with the DW1000 Version >=v2.16 of the user manual.

Fixes #2 